### PR TITLE
feat: search by regex

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,8 +49,9 @@
            return [];
          }
 
+	  const regex = RegExp(this.query)
           const results = this.packages.filter(pkg => {
-            return pkg.name.toLowerCase().includes(this.query.toLowerCase());
+            return regex.test(pkg.name);
           })
 
             this.more_results = results.length > 20;


### PR DESCRIPTION
Might as well. Fast enough. Backwards compatible since all special regex characters (e.g. `.`) are disallowed in package names.
![image](https://github.com/user-attachments/assets/02886d45-d907-447e-8b90-7f8bf0409cce)
